### PR TITLE
Add font color to inputs

### DIFF
--- a/foris/static/sass/ui/_forms.sass
+++ b/foris/static/sass/ui/_forms.sass
@@ -1,5 +1,6 @@
 input, textarea, select
   background-color: $background-color
+  color: $foreground-color
   border: 1px solid $stroke-color
   font-size: 130%
   padding: 0.2em


### PR DESCRIPTION
When using a dark system theme, text in input fields is light (therefore illegible) on white background.
