### PR TITLE
Change section title

### DIFF
--- a/foris/config_handlers/base.py
+++ b/foris/config_handlers/base.py
@@ -375,7 +375,7 @@ class NotificationsHandler(BaseConfigHandler):
 
         # reboot time
         reboot = notifications_form.add_section(name="reboot",
-                                                title=_("Automatic restarts"))
+                                                title=_("Automatic restarts after software update"))
         reboot.add_field(Number, name="delay", label=_("Delay (days)"),
                          hint=_("Number of days that must pass between receiving the request "
                                 "for restart and the automatic restart itself."),

--- a/foris/locale/cs/LC_MESSAGES/foris.po
+++ b/foris/locale/cs/LC_MESSAGES/foris.po
@@ -204,8 +204,8 @@ msgstr "Jméno"
 msgid "Password"
 msgstr "Heslo"
 
-msgid "Automatic restarts"
-msgstr "Automatické restarty"
+msgid "Automatic restarts after software update"
+msgstr "Automatické restarty po aktualizaci software"
 
 msgid "Delay (days)"
 msgstr "Prodleva (dny)"

--- a/foris/locale/de/LC_MESSAGES/foris.po
+++ b/foris/locale/de/LC_MESSAGES/foris.po
@@ -211,8 +211,8 @@ msgstr "Benutzername"
 msgid "Password"
 msgstr "Kennwort"
 
-msgid "Automatic restarts"
-msgstr "Automatischer Neustart"
+msgid "Automatic restarts after software update"
+msgstr "Automatische Neustarts nach Software-Update"
 
 msgid "Delay (days)"
 msgstr "Verzögerung (Tage)"


### PR DESCRIPTION
During the CZ.NIC course "Turris Omnia prakticky" there was a question of what is the purpose of the "Automatic restarts" section. Clearly, there has been some confusion. This patch should make it more clear.