### PR TITLE
Slovak translation update

### DIFF
--- a/foris/core.py
+++ b/foris/core.py
@@ -66,7 +66,7 @@ translation_names = {
     'cs': "Česky",
     'de': "Deutsch",
     'en': "English",
-    'sk': "Slovensky",
+    'sk': "Slovenský",
 }
 
 iso2to3 = {

--- a/foris/locale/sk/LC_MESSAGES/foris.po
+++ b/foris/locale/sk/LC_MESSAGES/foris.po
@@ -89,7 +89,7 @@ msgid "Maintenance"
 msgstr "Údržba"
 
 msgid "Wrong HTTP method."
-msgstr "Neplatná HTTP metóda"
+msgstr "Neplatná HTTP metóda."
 
 msgid "Testing message was sent, please check your inbox."
 msgstr ""
@@ -338,7 +338,7 @@ msgid "Send news"
 msgstr "Posielať novinky"
 
 msgid "Send emails about new features."
-msgstr "Posielať tiež upozornenia ohľadom nových funkcií routera"
+msgstr "Posielať tiež upozornenia ohľadom nových funkcií routera."
 
 msgid "SMTP settings"
 msgstr "Nastavenie SMTP"
@@ -373,8 +373,8 @@ msgstr "Meno"
 msgid "Password"
 msgstr "Heslo"
 
-msgid "Automatic restarts"
-msgstr "Automatické reštarty"
+msgid "Automatic restarts after software update"
+msgstr "Automatické reštarty po aktualizácii softvéru"
 
 msgid "Delay (days)"
 msgstr "Odklad (dni)"
@@ -992,7 +992,7 @@ msgstr ""
 "Pokiaľ ešte nemáte zariadenie zaregistrované v systéme Turris, kliknite na "
 "nasledujúce tlačidlo pre vygenerovanie registračného kódu. Ten následne "
 "vyplňte v svojom používateľskom profile v systéme Turris na adrese <a href="
-"\"%(url)s\">%(url)s</a>"
+"\"%(url)s\">%(url)s</a>."
 
 msgid "Registration code"
 msgstr "Registračný kód"
@@ -1527,7 +1527,7 @@ msgid "Time was successfully synchronized, you can move to the next step."
 msgstr "Čas bol úspešne synchronizovaný, môžete prejsť k ďalšiemu kroku."
 
 msgid "Project:Turris"
-msgstr "Project:Turris"
+msgstr "Projekt:Turris"
 
 msgid "Skip wizard"
 msgstr "Preskočiť sprievodcu"


### PR DESCRIPTION
Hello,
following commit updates Slovak translation with latest changes.

Note to translation_names array in core.py:
I assume that your intention is to display name of language as written in this language, e.g. German is Deutsch. For that reason I edited Slovak language name to "Slovenský", with accent mark at the end, which corresponds to how it should be written in Slovak language (in adjective form). As an alternate form it should be ok to use "Slovenčina" instead (which is in noun form).

Please let me know if there is anything to be done on my side to get this change merged.

Thank you.